### PR TITLE
2 classe icomponent

### DIFF
--- a/include/IComponent.hpp
+++ b/include/IComponent.hpp
@@ -9,9 +9,6 @@
 #define I_COMPONENT_HPP
 
 #include <cstddef>
-#include <string>
-#include <vector>
-#include <map>
 
 namespace nts
 {
@@ -39,12 +36,6 @@ namespace nts
                              std::size_t pinIn) = 0;
         virtual size_t pinOutToInternPin(size_t pin) = 0;
         virtual void setNotComputed() = 0;
-
-    protected:
-        std::string _name;
-        std::map<TypePin, std::map<IComponent &, std::size_t>> _inOuts;
-        std::vector<IComponent> _internComponents;
-        Tristate _lastValueComputed;
     };
 }
 


### PR DESCRIPTION
This pull request introduces a new header file `IComponent.hpp` which defines an interface for components in the `nts` namespace. The key changes include the addition of enums for tristate logic and pin types, as well as the declaration of the `IComponent` class with virtual functions and protected members.

New header file `IComponent.hpp`:

* Added the file header and inclusion guards to `IComponent.hpp`.
* Defined `Tristate` enum with values `NOTCOMPUTED`, `UNDEFINED`, `TRUE`, and `FALSE`.
* Defined `TypePin` enum with values `IN`, `OUT`, and `USELESS`.
* Declared the `IComponent` class with pure virtual functions `simulate`, `compute`, `setLink`, `pinOutToInternPin` and `setNotComputed`.
* Added protected members `_name`, `_inOuts`, `_internComponents` and `_lastValueComputed` to the `IComponent` class.