### PR TITLE
3 classe abstraite acomponent

### DIFF
--- a/include/AComponent.hpp
+++ b/include/AComponent.hpp
@@ -28,7 +28,7 @@ namespace nts
         virtual void setNotComputed() override;
         virtual size_t getIdFromPin(size_t pin) override;
         std::vector<std::pair<TypePin,
-            std::vector<std::pair<IComponent,
+            std::vector<std::pair<IComponent &,
             std::size_t>>>> getInOut() override;
 
     protected:
@@ -36,7 +36,7 @@ namespace nts
             : _name(name) {};
         std::string _name;
         std::vector<std::pair<TypePin,
-            std::vector<std::pair<IComponent,
+            std::vector<std::pair<IComponent &,
             std::size_t>>>> _inOuts;
         std::vector<IComponent> _internComponents;
         Tristate _lastValueComputed;

--- a/include/IComponent.hpp
+++ b/include/IComponent.hpp
@@ -39,7 +39,7 @@ namespace nts
         virtual void setNotComputed() = 0;
         virtual size_t getIdFromPin(size_t pin) = 0;
         virtual std::vector<std::pair<TypePin,
-                std::vector<std::pair<IComponent,
+                std::vector<std::pair<IComponent &,
                 std::size_t>>>> getInOut() = 0;
     };
 }

--- a/src/AComponent.cpp
+++ b/src/AComponent.cpp
@@ -7,16 +7,14 @@
 
 #include "AComponent.hpp"
 
-nts::AComponent::~AComponent()
-{
-}
-
 void nts::AComponent::simulate(std::size_t tick)
 {
+    tick = tick;
 }
 
 nts::Tristate nts::AComponent::compute(std::size_t pin)
 {
+    pin = pin;
     _lastValueComputed = UNDEFINED;
     return _lastValueComputed;
 }
@@ -28,9 +26,8 @@ void nts::AComponent::setLink(std::size_t pinOut, nts::IComponent &other,
         setLink(pinOut, _internComponents[getIdFromPin(pinOut)],
             _internComponents[getIdFromPin(pinOut)].pinOutToInternPin(pinOut));
     }
-    _inOuts[pinOut].second.push_back(std::make_pair(other, pinIn));
-    other.getInOut()[pinIn].second.push_back(
-        std::make_pair(dynamic_cast<IComponent &>(*this), pinOut));
+    _inOuts[pinOut].second.push_back(std::make_pair(std::ref(other), pinIn));
+    other.getInOut()[pinIn].second.push_back(std::make_pair(std::ref(*this), pinOut));
 }
 
 size_t nts::AComponent::pinOutToInternPin(size_t pin)
@@ -45,11 +42,12 @@ void nts::AComponent::setNotComputed()
 
 size_t nts::AComponent::getIdFromPin(size_t pin)
 {
+    pin = pin;
     return 0;
 }
 
 std::vector<std::pair<nts::TypePin,
-            std::vector<std::pair<nts::IComponent,
+            std::vector<std::pair<nts::IComponent &,
             std::size_t>>>> nts::AComponent::getInOut()
 {
     return _inOuts;


### PR DESCRIPTION
This pull request introduces a new class `AComponent` in the `nts` namespace, which implements the `IComponent` interface. It includes changes to both header and source files to define and implement the methods of `AComponent`.

### New Class Addition:

* [`include/AComponent.hpp`](diffhunk://#diff-736ea2d33c1dabc5be48e894c225ec737495f472bb2f2a3671596850e61db17aR1-R46): Added a new class `AComponent` that inherits from `IComponent` and implements its virtual methods. This class includes additional attributes and methods specific to `AComponent`.

### Interface Update:

* [`include/IComponent.hpp`](diffhunk://#diff-f8874d7d717b9b468e35efbcca7f5f57fa86967a0191ec4e69a993a0fb310aceR40-R43): Updated the `IComponent` interface to include new virtual methods `getIdFromPin` and `getInOut`.

### Implementation of Methods:

* [`src/AComponent.cpp`](diffhunk://#diff-66a4501203f2a53df14a43dccb8ee9adccfcb8c611d4403b3abc3b09fcc9f854R1-R54): Implemented the methods declared in `AComponent`, including `simulate`, `compute`, `setLink`, `pinOutToInternPin`, `setNotComputed`, `getIdFromPin`, and `getInOut`.

### Minor Include Addition:

* [`include/IComponent.hpp`](diffhunk://#diff-f8874d7d717b9b468e35efbcca7f5f57fa86967a0191ec4e69a993a0fb310aceR12): Added the `<utility>` header to support the use of `std::pair`.