### PR TITLE
✨  Implement ASingle component

### DIFF
--- a/include/ASingle.hpp
+++ b/include/ASingle.hpp
@@ -1,0 +1,18 @@
+/*
+** EPITECH PROJECT, 2025
+** NanoTekSpice
+** File description:
+** ASingle
+*/
+
+#pragma once
+#include "AComponent.hpp"
+#include <memory>
+
+namespace nts {
+    class ASingle : public AComponent
+    {
+        protected:
+            ASingle(std::string name);
+    };    
+}

--- a/src/ASingle.cpp
+++ b/src/ASingle.cpp
@@ -1,0 +1,24 @@
+/*
+** EPITECH PROJECT, 2025
+** NanoTekSpice
+** File description:
+** ASingle
+*/
+
+#include "ASingle.hpp"
+
+static std::pair<nts::TypePin, std::vector<std::pair<nts::IComponent &,
+    std::size_t>>> makePair(nts::TypePin type)
+{
+    return std::make_pair(type,
+        std::vector<std::pair<nts::IComponent &, std::size_t>>());
+}
+
+nts::ASingle::ASingle(std::string name) : AComponent(name)
+{
+    _inOuts.push_back(makePair(IN));
+    _inOuts.push_back(makePair(IN));
+    _inOuts.push_back(makePair(OUT));
+    _lastValueComputed = UNDEFINED;
+    _internComponents = std::vector<IComponent>();
+}


### PR DESCRIPTION
This pull request introduces a new class `ASingle` to the NanoTekSpice project, which is a subclass of `AComponent`. The changes include the addition of the class definition and its implementation.

New class addition:

* [`include/ASingle.hpp`](diffhunk://#diff-036da4644bedf5a10b24a3a98dccabf843be1eaa410c0e3135f6dbc4476c4a82R1-R18): Added the `ASingle` class definition, which inherits from `AComponent`. This class includes a protected constructor that takes a `std::string` as a parameter.

Class implementation:

* [`src/ASingle.cpp`](diffhunk://#diff-0d0c9871f642d2ad4abe1c2698693d831e5d2493cfd87873ca25560f3005d1baR1-R24): Implemented the `ASingle` constructor, initializing the `_inOuts` vector with input and output pairs, setting `_lastValueComputed` to `UNDEFINED`, and initializing `_internComponents` as an empty vector. Additionally, a static helper function `makePair` is defined to create pairs of `TypePin` and vectors of component references.