### PR TITLE
✨ Add ComponentOr class and tests

### DIFF
--- a/include/ComponentOr.hpp
+++ b/include/ComponentOr.hpp
@@ -1,0 +1,23 @@
+/*
+** EPITECH PROJECT, 2025
+** ComponentOr.hpp
+** File description:
+** ComponentOr.hpp
+*/
+
+#ifndef COMPONENT_OR_HPP
+#define COMPONENT_OR_HPP
+
+#include "ASingle.hpp"
+
+namespace nts
+{
+    class ComponentOr : public ASingle
+    {
+    public:
+        ComponentOr(std::string name);
+        Tristate compute(std::size_t pin) override;
+    };
+}
+
+#endif /* !COMPONENT_OR_HPP */

--- a/src/Component/ComponentOr.cpp
+++ b/src/Component/ComponentOr.cpp
@@ -1,0 +1,36 @@
+/*
+** EPITECH PROJECT, 2025
+** ComponentOr.cpp
+** File description:
+** ComponentOr.cpp
+*/
+
+#include "ComponentOr.hpp"
+
+nts::ComponentOr::ComponentOr(std::string name)
+    : ASingle(name)
+{
+}
+
+static nts::Tristate orTristate(nts::Tristate val1, nts::Tristate val2)
+{
+    if (val1 == nts::TRUE || val2 == nts::TRUE)
+        return nts::TRUE;
+    if (val1 == nts::UNDEFINED || val2 == nts::UNDEFINED)
+        return nts::UNDEFINED;
+    return nts::FALSE;
+}
+
+nts::Tristate nts::ComponentOr::compute(std::size_t pin)
+{
+    nts::Tristate val1;
+    nts::Tristate val2;
+
+    if (_ValueComputed == NOTCOMPUTED) {
+        _ValueComputed = COMPUTING;
+        val1 = getVal(0);
+        val2 = getVal(1);
+        _ValueComputed = orTristate(val1, val2);
+    }
+    return safeReturn(pin);
+}

--- a/tests/TestsComponentOr.cpp
+++ b/tests/TestsComponentOr.cpp
@@ -1,0 +1,106 @@
+/*
+** EPITECH PROJECT, 2025
+** TestsComponentOr.cpp
+** File description:
+** TestsComponentOr.cpp
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+
+#include "../include/ComponentTrue.hpp"
+#include "../include/ComponentFalse.hpp"
+#include "../include/ComponentOr.hpp"
+#include "../include/ComponentInput.hpp"
+
+static void redirect_all_std(void)
+{
+    cr_redirect_stdout();
+    cr_redirect_stderr();
+}
+
+Test(ComponentOr, compute_or_true, .init=redirect_all_std)
+{
+    nts::ComponentOr componentOr("or");
+    nts::ComponentTrue componentTrue("1");
+
+    componentOr.setLink(1, componentTrue, 1);
+    componentOr.setLink(2, componentTrue, 1);
+    componentOr.setNotComputed();
+    cr_assert_eq(componentOr.compute(0), nts::TRUE);
+}
+
+Test(ComponentOr, compute_or_false, .init=redirect_all_std)
+{
+    nts::ComponentOr componentOr("or");
+    nts::ComponentFalse componentFalse("1");
+
+    componentOr.setLink(1, componentFalse, 1);
+    componentOr.setLink(2, componentFalse, 1);
+    componentOr.setNotComputed();
+    cr_assert_eq(componentOr.compute(0), nts::FALSE);
+}
+
+Test(ComponentOr, compute_or_UNDEFINED, .init=redirect_all_std)
+{
+    nts::ComponentOr componentOr("or");
+    nts::ComponentTrue componentTrue("1");
+    nts::ComponentInput componentInput("2");
+
+    componentOr.setLink(1, componentTrue, 1);
+    componentOr.setLink(2, componentInput, 1);
+    componentOr.setNotComputed();
+    cr_assert_eq(componentOr.compute(0), nts::TRUE);
+}
+
+Test(ComponentOr, compute_or_NoLink, .init=redirect_all_std)
+{
+    nts::ComponentOr componentOr("or");
+
+    componentOr.setNotComputed();
+    cr_assert_eq(componentOr.compute(0), nts::UNDEFINED);
+}
+
+Test(ComponentOr, compute_or_AutoLink, .init=redirect_all_std)
+{
+    nts::ComponentOr componentOr("or");
+
+    componentOr.setLink(3, componentOr, 2);
+    componentOr.setNotComputed();
+    cr_assert_eq(componentOr.compute(0), nts::UNDEFINED);
+}
+
+Test(ComponentOr, compute_or_AutoLinkFalse, .init=redirect_all_std)
+{
+    nts::ComponentOr componentOr("or");
+    nts::ComponentFalse componentFalse("1");
+
+    componentOr.setLink(3, componentOr, 2);
+    componentOr.setLink(1, componentFalse, 1);
+    componentOr.setNotComputed();
+    cr_assert_eq(componentOr.compute(0), nts::UNDEFINED);
+}
+
+Test(ComponentOr, compute_or_double_AutoLink, .init=redirect_all_std)
+{
+    nts::ComponentOr componentOr("or");
+    nts::ComponentOr componentOr2("or2");
+
+    componentOr.setLink(3, componentOr2, 2);
+    componentOr2.setLink(3, componentOr, 1);
+    componentOr2.setNotComputed();
+    componentOr.setNotComputed();
+    cr_assert_eq(componentOr.compute(0), nts::UNDEFINED);
+}
+
+Test(ComponentOr, compute_or_double_AutoLink2, .init=redirect_all_std)
+{
+    nts::ComponentOr componentOr("or");
+    nts::ComponentOr componentOr2("or2");
+
+    componentOr.setLink(3, componentOr2, 2);
+    componentOr2.setLink(3, componentOr, 1);
+    componentOr2.setNotComputed();
+    componentOr.setNotComputed();
+    cr_assert_eq(componentOr2.compute(0), nts::UNDEFINED);
+}


### PR DESCRIPTION
This pull request introduces a new `ComponentOr` class in the `nts` namespace, which implements the OR logic gate functionality. It also includes corresponding unit tests to ensure the correct behavior of the `ComponentOr` class.

### Addition of `ComponentOr` class:

* [`include/ComponentOr.hpp`](diffhunk://#diff-047bff46d4079ab73aed109773d5a9a15135a715189b1a2d8bd8302d66a38c2fR1-R23): Added the header file defining the `ComponentOr` class, which inherits from `ASingle` and overrides the `compute` method.
* [`src/Component/ComponentOr.cpp`](diffhunk://#diff-8db5bc172771c0744858df1ca438d709e809cab5689163ec8911731fe63f6860R1-R36): Implemented the `ComponentOr` class, including the constructor and the `compute` method, which uses a helper function `orTristate` to perform the OR operation on tristate values.

### Unit tests for `ComponentOr`:

* [`tests/TestsComponentOr.cpp`](diffhunk://#diff-6f5721e7b08e3b0472cfac7bd7c04ea343299753ad0ee07747262d94f75cade3R1-R106): Added unit tests for the `ComponentOr` class to verify its behavior with different input combinations, including true, false, undefined, no link, auto link, and double auto link scenarios.