### PR TITLE
✨ Add ComponentNot class and tests

### DIFF
--- a/include/ComponentNot.hpp
+++ b/include/ComponentNot.hpp
@@ -1,0 +1,24 @@
+/*
+** EPITECH PROJECT, 2025
+** ComponentNot.hpp
+** File description:
+** ComponentNot.hpp
+*/
+
+#ifndef COMPONENT_NOT_HPP
+#define COMPONENT_NOT_HPP
+
+#include "AComponent.hpp"
+
+namespace nts
+{
+    class ComponentNot : public AComponent
+    {
+    public:
+        ComponentNot(std::string name);
+        ~ComponentNot();
+        nts::Tristate compute(std::size_t pin) override;
+    };
+}
+
+#endif /* !COMPONENT_NOT_HPP */

--- a/src/Component/ComponentNot.cpp
+++ b/src/Component/ComponentNot.cpp
@@ -1,0 +1,39 @@
+/*
+** EPITECH PROJECT, 2025
+** ComponentNot.cpp
+** File description:
+** ComponentNot.cpp
+*/
+
+#include "ComponentNot.hpp"
+
+nts::ComponentNot::ComponentNot(std::string name)
+    : AComponent(name)
+{
+    _inOuts.push_back(std::make_pair(IN, std::vector<std::pair<IComponent &, std::size_t>>()));
+    _inOuts.push_back(std::make_pair(OUT, std::vector<std::pair<IComponent &, std::size_t>>()));
+    _lastValue[0] = UNDEFINED;
+    _ValueComputed = UNDEFINED;
+}
+
+nts::ComponentNot::~ComponentNot() {}
+
+nts::Tristate notTristate(nts::Tristate val)
+{
+    if (val == nts::UNDEFINED)
+        return nts::UNDEFINED;
+    return (val == nts::TRUE) ? nts::FALSE : nts::TRUE;
+}
+
+nts::Tristate nts::ComponentNot::compute(std::size_t pin)
+{
+    if (_ValueComputed == NOTCOMPUTED) {
+        _ValueComputed = COMPUTING;
+        if (_inOuts[0].second.size() == 0) {
+            _ValueComputed = UNDEFINED;
+        } else {
+            _ValueComputed = notTristate(_inOuts[0].second[0].first.compute(_inOuts[0].second[0].second));
+        }
+    }
+    return safeReturn(pin);
+}

--- a/src/Component/ComponentOutput.cpp
+++ b/src/Component/ComponentOutput.cpp
@@ -27,6 +27,5 @@ nts::Tristate nts::ComponentOutput::compute(std::size_t pin)
             _ValueComputed = _inOuts[0].second[0].first.compute(_inOuts[0].second[0].second);
         }
     }
-    _lastValue[pin] = _ValueComputed;
-    return _ValueComputed;
+    return safeReturn(pin);
 }

--- a/tests/TestsComponentNot.cpp
+++ b/tests/TestsComponentNot.cpp
@@ -1,0 +1,81 @@
+/*
+** EPITECH PROJECT, 2025
+** TestsComponentNot.cpp
+** File description:
+** TestsComponentNot.cpp
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+
+#include "../include/ComponentNot.hpp"
+#include "../include/ComponentTrue.hpp"
+#include "../include/ComponentFalse.hpp"
+#include "../include/ComponentInput.hpp"
+
+static void redirect_all_std(void)
+{
+    cr_redirect_stdout();
+    cr_redirect_stderr();
+}
+
+Test(ComponentNot, compute, .init=redirect_all_std)
+{
+    nts::ComponentNot componentNot("not");
+
+    cr_assert_eq(componentNot.compute(0), nts::UNDEFINED);
+}
+
+Test(ComponentNot, computeLinkedTrue, .init=redirect_all_std)
+{
+    nts::ComponentNot componentNot("not");
+    nts::ComponentTrue componentTrue("true");
+
+    componentNot.setNotComputed();
+    componentTrue.setLink(1, componentNot, 1);
+    cr_assert_eq(componentNot.compute(0), nts::FALSE);
+}
+
+Test(ComponentNot, computeLinkedFalse, .init=redirect_all_std)
+{
+    nts::ComponentNot componentNot("not");
+    nts::ComponentFalse componentFalse("false");
+
+    componentNot.setNotComputed();
+    componentFalse.setLink(1, componentNot, 1);
+    cr_assert_eq(componentNot.compute(0), nts::TRUE);
+}
+
+Test(ComponentNot, computeLinkedInput, .init=redirect_all_std)
+{
+    nts::ComponentNot componentNot("not");
+    nts::ComponentInput componentInput("in");
+
+    componentNot.setNotComputed();
+    componentInput.setLink(1, componentNot, 1);
+    cr_assert_eq(componentNot.compute(0), nts::UNDEFINED);
+    componentNot.setNotComputed();
+    componentInput.setValue(nts::TRUE);
+    cr_assert_eq(componentNot.compute(0), nts::FALSE);
+    componentNot.setNotComputed();
+    componentInput.setValue(nts::FALSE);
+    cr_assert_eq(componentNot.compute(0), nts::TRUE);
+}
+
+Test(ComponentNot, setNotComputed, .init=redirect_all_std)
+{
+    nts::ComponentNot componentNot("not");
+
+    componentNot.setNotComputed();
+    cr_assert_eq(componentNot.compute(0), nts::UNDEFINED);
+}
+
+Test(ComponentNot, PinUnexisting, .init=redirect_all_std)
+{
+    nts::ComponentNot componentNot("not");
+    nts::ComponentInput componentInput("in");
+
+    componentNot.setNotComputed();
+    cr_assert_throw(componentInput.setLink(1, componentNot, 21), nts::AComponent::Errors);
+    cr_assert_throw(componentInput.setLink(21, componentNot, 1), nts::AComponent::Errors);
+}


### PR DESCRIPTION
This pull request introduces the `ComponentNot` class and includes its implementation, as well as adding tests for this new component. The main changes involve the creation of the `ComponentNot` class, its corresponding methods, and the addition of tests to ensure its proper functionality.

### Introduction of `ComponentNot` class:

* [`include/ComponentNot.hpp`](diffhunk://#diff-4a1b524561fbd7069a3196d4060f232d7b4f4463ac70edc6599506b2dbdd27d3R1-R24): Added the header file for the `ComponentNot` class, which inherits from `AComponent` and overrides the `compute` method.
* [`src/Component/ComponentNot.cpp`](diffhunk://#diff-3068ab3ce39401ea9cd4a41174555afee63c3c6c91e68067abc199ba467808b0R1-R39): Implemented the `ComponentNot` class, including its constructor, destructor, and the `compute` method. Also defined a helper function `notTristate` to handle the NOT operation on tristate values.

### Modifications to existing components:

* [`src/Component/ComponentOutput.cpp`](diffhunk://#diff-977194bde6b1652e3d30aacf0416e281d0d74fc96198a42c2ee05538166de643L30-R30): Modified the `compute` method in `ComponentOutput` to use the `safeReturn` method for returning computed values.

### Testing the `ComponentNot` class:

* [`tests/TestsComponentNot.cpp`](diffhunk://#diff-63ce56326db2ab8cac45d0eeb8314fd4c636b6a101de0146193fbe119dfb16beR1-R81): Added a series of tests for the `ComponentNot` class to verify its `compute` method with various input scenarios, including linking with other components and handling undefined states.