### PR TITLE
✨ new Component 4011

### DIFF
--- a/include/Component4011.hpp
+++ b/include/Component4011.hpp
@@ -1,0 +1,23 @@
+/*
+** EPITECH PROJECT, 2025
+** ComponentAnd.hpp
+** File description:
+** ComponentAnd.hpp
+*/
+
+#ifndef COMPONENT_4011_HPP
+#define COMPONENT_4011_HPP
+
+#include "AFourGates.hpp"
+#include "ComponentNand.hpp"
+
+namespace nts
+{
+    class Component4011 : public AFourGates
+    {
+        public:
+            Component4011(std::string name);
+    };
+}
+
+#endif /* !COMPONENT_4011_HPP */

--- a/src/Component/Component4011.cpp
+++ b/src/Component/Component4011.cpp
@@ -1,0 +1,17 @@
+/*
+** EPITECH PROJECT, 2025
+** NanoTekSpice
+** File description:
+** Component4011
+*/
+
+#include "Component4011.hpp"
+
+nts::Component4011::Component4011(std::string name)
+    : AFourGates(name)
+{
+    _internComponents.push_back(std::make_shared<ComponentNand>(""));
+    _internComponents.push_back(std::make_shared<ComponentNand>(""));
+    _internComponents.push_back(std::make_shared<ComponentNand>(""));
+    _internComponents.push_back(std::make_shared<ComponentNand>(""));
+}

--- a/tests/TestsComponent4011.cpp
+++ b/tests/TestsComponent4011.cpp
@@ -1,0 +1,236 @@
+/*
+** EPITECH PROJECT, 2025
+** TestsComponentTrue.cpp
+** File description:
+** TestsComponentTrue.cpp
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+
+#include "../include/ComponentTrue.hpp"
+#include "../include/ComponentFalse.hpp"
+#include "../include/Component4011.hpp"
+#include "../include/ComponentInput.hpp"
+#include "../include/ComponentOutput.hpp"
+
+static void redirect_all_std(void)
+{
+    cr_redirect_stdout();
+    cr_redirect_stderr();
+}
+
+Test(Component4011, defaultStat, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+
+    component4011.setNotComputed();
+    cr_assert_eq(component4011.compute(0), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(1), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(2), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(3), nts::UNDEFINED);
+}
+
+Test(Component4011, firstTrue, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue1("t1");
+    nts::ComponentTrue componentTrue2("t2");
+
+    component4011.setLink(1, componentTrue1, 1);
+    component4011.setLink(2, componentTrue2, 1);
+
+    component4011.setNotComputed();
+    cr_assert_eq(component4011.compute(0), nts::FALSE);
+    cr_assert_eq(component4011.compute(1), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(2), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(3), nts::UNDEFINED);
+}
+
+Test(Component4011, SecondTrue, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue1("t1");
+    nts::ComponentTrue componentTrue2("t2");
+
+    component4011.setLink(5, componentTrue1, 1);
+    component4011.setLink(6, componentTrue2, 1);
+
+    component4011.setNotComputed();
+    cr_assert_eq(component4011.compute(0), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(1), nts::FALSE);
+    cr_assert_eq(component4011.compute(2), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(3), nts::UNDEFINED);
+}
+Test(Component4011, ThreeTrue, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue1("t1");
+    nts::ComponentTrue componentTrue2("t2");
+
+    component4011.setLink(8, componentTrue1, 1);
+    component4011.setLink(9, componentTrue2, 1);
+
+    component4011.setNotComputed();
+    cr_assert_eq(component4011.compute(0), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(1), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(2), nts::FALSE);
+    cr_assert_eq(component4011.compute(3), nts::UNDEFINED);
+}
+Test(Component4011, FourTrue, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue1("t1");
+    nts::ComponentTrue componentTrue2("t2");
+
+    component4011.setLink(13, componentTrue1, 1);
+    component4011.setLink(12, componentTrue2, 1);
+
+    component4011.setNotComputed();
+    cr_assert_eq(component4011.compute(0), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(1), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(2), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(3), nts::FALSE);
+}
+
+Test(Component4011, FourTrueInverted_Sens, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue1("t1");
+    nts::ComponentTrue componentTrue2("t2");
+
+    componentTrue1.setLink(1, component4011, 13);
+    componentTrue2.setLink(1, component4011, 12);
+
+    component4011.setNotComputed();
+    cr_assert_eq(component4011.compute(0), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(1), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(2), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(3), nts::FALSE);
+}
+
+Test(Component4011, FourTrueMultiple, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue1("t1");
+    nts::ComponentTrue componentTrue2("t2");
+    nts::ComponentFalse componentFalse("f1");
+
+    componentTrue1.setLink(1, component4011, 13);
+    componentTrue2.setLink(1, component4011, 12);
+    component4011.setLink(1, componentTrue1, 1);
+    component4011.setLink(2, componentFalse, 1);
+
+    component4011.setNotComputed();
+    cr_assert_eq(component4011.compute(0), nts::TRUE);
+    cr_assert_eq(component4011.compute(1), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(2), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(3), nts::FALSE);
+}
+
+Test(Component4011, SecondTrueNotComputed, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue1("t1");
+    nts::ComponentTrue componentTrue2("t2");
+
+    component4011.setLink(5, componentTrue1, 1);
+    component4011.setLink(6, componentTrue2, 1);
+
+    cr_assert_eq(component4011.compute(0), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(1), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(2), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(3), nts::UNDEFINED);
+}
+
+Test(Component4011, TwoComponentLinked, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::Component4011 component4011_2("4011_2");
+    nts::ComponentTrue componentTrue("t");
+
+    component4011.setLink(1, componentTrue, 1);
+    component4011.setLink(2, componentTrue, 1);
+    component4011_2.setLink(2, componentTrue, 1);
+    component4011_2.setLink(1, component4011, 3);
+
+    component4011.setNotComputed();
+    component4011_2.setNotComputed();
+    cr_assert_eq(component4011_2.compute(0), nts::TRUE);
+}
+
+Test(Component4011, TwoComponentLinked_two, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::Component4011 component4011_2("4011_2");
+    nts::ComponentTrue componentTrue("t");
+
+    component4011.setLink(5, componentTrue, 1);
+    component4011.setLink(6, componentTrue, 1);
+    component4011_2.setLink(2, componentTrue, 1);
+    component4011_2.setLink(1, component4011, 4);
+
+    component4011.setNotComputed();
+    component4011_2.setNotComputed();
+    cr_assert_eq(component4011_2.compute(0), nts::TRUE);
+}
+
+Test(Component4011, TwoComponentLinked_output, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::Component4011 component4011_2("4011_2");
+    nts::ComponentTrue componentTrue("t");
+    nts::ComponentOutput componentOutput("output");
+
+    component4011.setLink(5, componentTrue, 1);
+    component4011.setLink(6, componentTrue, 1);
+    component4011_2.setLink(8, componentTrue, 1);
+    component4011_2.setLink(9, component4011, 4);
+    componentOutput.setLink(1, component4011_2, 10);
+
+    component4011.setNotComputed();
+    component4011_2.setNotComputed();
+    componentOutput.setNotComputed();
+    cr_assert_eq(componentOutput.compute(0), nts::TRUE);
+}
+
+Test(Component4011, PinOut_and_PinIn_are_both_IN, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue("t1");
+
+    component4011.setLink(5, componentTrue, 1);
+    cr_assert_throw(component4011.setLink(6, component4011, 1), nts::AComponent::Errors);
+}
+
+Test(Component4011, PinOut_and_PinIn_are_both_OUT, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue("t1");
+
+    component4011.setLink(5, componentTrue, 1);
+    cr_assert_throw(component4011.setLink(3, component4011, 4), nts::AComponent::Errors);
+}
+
+Test(Component4011, autoLink, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue("t1");
+
+    component4011.setLink(5, componentTrue, 1);
+    component4011.setLink(6, component4011, 4);
+    component4011.setNotComputed();
+    cr_assert_eq(component4011.compute(0), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(1), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(2), nts::UNDEFINED);
+    cr_assert_eq(component4011.compute(3), nts::UNDEFINED);
+}
+
+Test(Component4011, linkToNoOutput, .init=redirect_all_std)
+{
+    nts::Component4011 component4011("4011");
+    nts::ComponentTrue componentTrue("t1");
+
+    component4011.setLink(5, componentTrue, 1);
+    cr_assert_throw(component4011.setLink(7, component4011, 4), nts::AComponent::Errors);
+}


### PR DESCRIPTION
This pull request introduces a new `Component4011` class, which represents a 4011 NAND gate component, along with its associated tests. The changes include the addition of the class definition, its implementation, and comprehensive tests to ensure its correct functionality.

### New Component Addition:

* [`include/Component4011.hpp`](diffhunk://#diff-d7b22458b88d14386835b2f56de43a71431790d5134554545448efc9497c0d40R1-R23): Added the header file for the `Component4011` class, which inherits from `AFourGates` and includes four internal `ComponentNand` instances.
* [`src/Component/Component4011.cpp`](diffhunk://#diff-e0dcddabf004098c61229db57ad919a39b35b8cef8ece0575abfc67781f1f51eR1-R17): Implemented the constructor for `Component4011`, initializing the four internal `ComponentNand` components.

### Testing:

* [`tests/TestsComponent4011.cpp`](diffhunk://#diff-e677597fb7c0c3163163c4339fa55952f00f7f3af79d9fdd94a2352952bf4b73R1-R236): Added extensive tests for the `Component4011` class, covering various scenarios such as default state, linking with other components, and edge cases.