### PR TITLE
87 fix parsing file with empty component and links

### DIFF
--- a/src/Parsing/Parsing.cpp
+++ b/src/Parsing/Parsing.cpp
@@ -87,6 +87,9 @@ std::vector<std::string> getPartList(std::vector<std::string> lines,
     }
     if (pos == -1)
         throw std::invalid_argument("Error: Unable to find " + start);
+    if (linesInPart.size() == 0)
+        throw std::invalid_argument("Error: No content between " + start +
+            " and " + stop);
     return linesInPart;
 }
 

--- a/tests/Exemple/nts_single/nothing.nts
+++ b/tests/Exemple/nts_single/nothing.nts
@@ -1,0 +1,3 @@
+.chipsets:
+
+.links:

--- a/tests/Parsing/TestsParsing.cpp
+++ b/tests/Parsing/TestsParsing.cpp
@@ -204,3 +204,16 @@ Test(ParseBySpaces, xorLink, .init=redirect_all_std)
     cr_assert_str_eq(newLink[2][2].c_str(), "gate");
     cr_assert_str_eq(newLink[2][3].c_str(), "3");
 }
+
+Test(init, empty_chipset_and_link, .init=redirect_all_std)
+{
+    std::string a = parseFile("tests/Exemple/nts_single/nothing.nts");
+    std::vector<std::string> b = parseByLine(a);
+    std::vector<std::string> c = removeCommentary(b);
+
+    try {
+        std::vector<std::string> link = getPartList(c, ".links:", ".chipsets:");
+    } catch (const std::exception &e) {
+        cr_assert_str_eq(e.what(), "Error: No content between .links: and .chipsets:");
+    }
+}


### PR DESCRIPTION
This pull request includes changes to improve error handling in the `getPartList` function and adds a new test case to ensure the robustness of the parsing functionality. The most important changes include adding an exception for empty content between specified markers and creating a corresponding test case to validate this behavior.

Improvements to error handling:

* [`src/Parsing/Parsing.cpp`](diffhunk://#diff-540f79869abc1d7610dec85a5ff5c72afbdec4b8f25b6d0f3443f723b5be77d6R90-R92): Added a check to throw an `std::invalid_argument` exception if there is no content between the specified start and stop markers in the `getPartList` function.

Enhancements to testing:

* [`tests/Parsing/TestsParsing.cpp`](diffhunk://#diff-884242d6095c874a872d9af81b2414b5e498655dc07e35bbbcd3d58a5ee7f7e6R207-R219): Added a new test case `Test(init, empty_chipset_and_link, .init=redirect_all_std)` to verify that the `getPartList` function correctly throws an exception when there is no content between `.links:` and `.chipsets:`.

Other changes:

* [`tests/Exemple/nts_single/nothing.nts`](diffhunk://#diff-10547abb6588a8e743506872cae92cf2a79fb2f16f5727b03584d2c1b4cb0785R1-R3): Added empty `.chipsets:` and `.links:` sections to the test file to support the new test case.