### PR TITLE
90 fix basic component

### DIFF
--- a/include/Component/Input/ComponentClock.hpp
+++ b/include/Component/Input/ComponentClock.hpp
@@ -24,6 +24,7 @@ namespace nts
 
     private:
         Tristate _value;
+        Tristate _valueComputed;
     };
 }
 

--- a/include/Component/Input/ComponentInput.hpp
+++ b/include/Component/Input/ComponentInput.hpp
@@ -23,6 +23,7 @@ namespace nts
 
     private:
         Tristate _value;
+        Tristate _valueComputed;
     };
 }
 

--- a/src/Component/Input/ComponentClock.cpp
+++ b/src/Component/Input/ComponentClock.cpp
@@ -11,6 +11,7 @@ nts::ComponentClock::ComponentClock(std::string name)
     : AInput(name)
 {
     _value = nts::UNDEFINED;
+    _valueComputed = nts::UNDEFINED;
 }
 
 nts::ComponentClock::~ComponentClock()
@@ -32,7 +33,8 @@ void nts::ComponentClock::simulate(std::size_t tick)
 nts::Tristate nts::ComponentClock::compute(std::size_t pin)
 {
     (void)pin;
-    return _value;
+    _valueComputed = _value;
+    return _valueComputed;
 }
 
 void nts::ComponentClock::setValue(nts::Tristate value)
@@ -42,5 +44,5 @@ void nts::ComponentClock::setValue(nts::Tristate value)
 
 nts::Tristate nts::ComponentClock::getValueComputed()
 {
-    return _value;
+    return _valueComputed;
 }

--- a/src/Component/Input/ComponentFalse.cpp
+++ b/src/Component/Input/ComponentFalse.cpp
@@ -10,6 +10,7 @@
 nts::ComponentFalse::ComponentFalse(std::string name)
     : AInput(name)
 {
+    _value = FALSE;
 }
 
 nts::ComponentFalse::~ComponentFalse()
@@ -19,8 +20,6 @@ nts::ComponentFalse::~ComponentFalse()
 void nts::ComponentFalse::simulate(std::size_t tick)
 {
     (void)tick;
-    if (_value == UNDEFINED)
-        _value = FALSE;
 }
 
 nts::Tristate nts::ComponentFalse::compute(std::size_t pin)

--- a/src/Component/Input/ComponentInput.cpp
+++ b/src/Component/Input/ComponentInput.cpp
@@ -11,6 +11,7 @@ nts::ComponentInput::ComponentInput(std::string name)
     : AInput(name)
 {
     _value = nts::UNDEFINED;
+    _valueComputed = nts::UNDEFINED;
 }
 
 nts::ComponentInput::~ComponentInput()
@@ -20,7 +21,8 @@ nts::ComponentInput::~ComponentInput()
 nts::Tristate nts::ComponentInput::compute(std::size_t pin)
 {
     (void)pin;
-    return _value;
+    _valueComputed = _value;
+    return _valueComputed;
 }
 
 void nts::ComponentInput::setValue(nts::Tristate value)
@@ -30,5 +32,5 @@ void nts::ComponentInput::setValue(nts::Tristate value)
 
 nts::Tristate nts::ComponentInput::getValueComputed()
 {
-    return _value;
+    return _valueComputed;
 }

--- a/src/Component/Input/ComponentTrue.cpp
+++ b/src/Component/Input/ComponentTrue.cpp
@@ -10,6 +10,7 @@
 nts::ComponentTrue::ComponentTrue(std::string name)
     : AInput(name)
 {
+    _value = TRUE;
 }
 
 nts::ComponentTrue::~ComponentTrue()
@@ -25,6 +26,4 @@ nts::Tristate nts::ComponentTrue::compute(std::size_t pin)
 void nts::ComponentTrue::simulate(std::size_t tick)
 {
     (void)tick;
-    if (_value == UNDEFINED)
-        _value = TRUE;
 }


### PR DESCRIPTION
This pull request includes several changes to the `ComponentClock`, `ComponentInput`, `ComponentFalse`, and `ComponentTrue` classes to enhance their functionality and improve code readability. The most important changes include adding a new `_valueComputed` variable and updating the `compute` and `getValueComputed` methods accordingly.

Enhancements to `ComponentClock` and `ComponentInput`:

* [`include/Component/Input/ComponentClock.hpp`](diffhunk://#diff-ceecafd2bcfd2cd4504e00b83ca4f6ed0a25ac251fd9338d21e7531c1c6f043bR27): Added a new private member variable `Tristate _valueComputed` to the `ComponentClock` class.
* [`include/Component/Input/ComponentInput.hpp`](diffhunk://#diff-5c6e21abc0c5cc8ab93096fd42482b5285d0760bf4ee2a90259964a6726f1f1bR26): Added a new private member variable `Tristate _valueComputed` to the `ComponentInput` class.
* [`src/Component/Input/ComponentClock.cpp`](diffhunk://#diff-5a31934e2bbdd43807cb8b89e1e6bafe96fd91d079156dccca3aca3678af192dR14): Modified the constructor to initialize `_valueComputed`, updated the `compute` method to set `_valueComputed` before returning it, and updated the `getValueComputed` method to return `_valueComputed`. [[1]](diffhunk://#diff-5a31934e2bbdd43807cb8b89e1e6bafe96fd91d079156dccca3aca3678af192dR14) [[2]](diffhunk://#diff-5a31934e2bbdd43807cb8b89e1e6bafe96fd91d079156dccca3aca3678af192dL35-R37) [[3]](diffhunk://#diff-5a31934e2bbdd43807cb8b89e1e6bafe96fd91d079156dccca3aca3678af192dL45-R47)
* [`src/Component/Input/ComponentInput.cpp`](diffhunk://#diff-94d518f0a5174870eec4335a6cb8fb8358a30b4997b4d086d73963c43a191084R14): Modified the constructor to initialize `_valueComputed`, updated the `compute` method to set `_valueComputed` before returning it, and updated the `getValueComputed` method to return `_valueComputed`. [[1]](diffhunk://#diff-94d518f0a5174870eec4335a6cb8fb8358a30b4997b4d086d73963c43a191084R14) [[2]](diffhunk://#diff-94d518f0a5174870eec4335a6cb8fb8358a30b4997b4d086d73963c43a191084L23-R25) [[3]](diffhunk://#diff-94d518f0a5174870eec4335a6cb8fb8358a30b4997b4d086d73963c43a191084L33-R35)

Improvements to `ComponentFalse` and `ComponentTrue`:

* [`src/Component/Input/ComponentFalse.cpp`](diffhunk://#diff-dc135d4daa42abab8f5fb3b64efea547471c38e014862bd07553eb062fb61565R13): Set `_value` to `FALSE` in the constructor and removed redundant code from the `simulate` method. [[1]](diffhunk://#diff-dc135d4daa42abab8f5fb3b64efea547471c38e014862bd07553eb062fb61565R13) [[2]](diffhunk://#diff-dc135d4daa42abab8f5fb3b64efea547471c38e014862bd07553eb062fb61565L22-L23)
* [`src/Component/Input/ComponentTrue.cpp`](diffhunk://#diff-e07dbdc06811ec86c8ecdb51e8d5ee9c6ca434a57d71a209cc3161972cb0cf10R13): Set `_value` to `TRUE` in the constructor and removed redundant code from the `simulate` method. [[1]](diffhunk://#diff-e07dbdc06811ec86c8ecdb51e8d5ee9c6ca434a57d71a209cc3161972cb0cf10R13) [[2]](diffhunk://#diff-e07dbdc06811ec86c8ecdb51e8d5ee9c6ca434a57d71a209cc3161972cb0cf10L28-L29)