### PR TITLE
🐛 Fix Simulate not starting at creation & 4017 not in factory

### DIFF
--- a/include/Component/Other/Circuit.hpp
+++ b/include/Component/Other/Circuit.hpp
@@ -21,6 +21,7 @@ namespace nts
     public:
         Circuit();
         void simulate(std::size_t tick);
+        void simulate();
         nts::Tristate compute(std::size_t pin);
         void display(void);
         void setValue(std::string const &name, nts::Tristate value);
@@ -28,7 +29,7 @@ namespace nts
         IComponent &getComponent(std::string const &name);
 
     private:
-        std::size_t _ticks_passed;
+        size_t _ticks_passed;
     };
 }
 

--- a/src/Component/Other/Circuit.cpp
+++ b/src/Component/Other/Circuit.cpp
@@ -16,6 +16,17 @@ nts::Circuit::Circuit()
     _ticks_passed = 0;
 }
 
+void nts::Circuit::simulate()
+{
+    for (auto &component : _internComponents) {
+        component->setNotComputed();
+    }
+    for (auto &component : _internComponents) {
+        if (dynamic_cast<nts::ComponentOutput *>(component.get()))
+            component->compute(0);
+    }
+}
+
 void nts::Circuit::simulate(std::size_t tick)
 {
     _ticks_passed += tick;

--- a/src/Factory/ComponentFactory.cpp
+++ b/src/Factory/ComponentFactory.cpp
@@ -47,6 +47,7 @@ nts::ComponentFactory::ComponentFactory()
         {"4081", []() { return std::make_unique<nts::Component4081>("4081"); }},
         {"4008", []() { return std::make_unique<nts::Component4008>("4008"); }},
         {"4008", []() { return std::make_unique<nts::Component4008>("4008"); }},
+        {"4017", []() { return std::make_unique<nts::Component4017>("4017"); }},
         {"4040", []() { return std::make_unique<nts::Component4040>("4040"); }}
     };
 }

--- a/src/Parsing/Parse.cpp
+++ b/src/Parsing/Parse.cpp
@@ -37,6 +37,7 @@ static int init(std::vector<std::vector<std::string>> chipsets,
             std::size_t pin2 = std::stoul(link[3]);
             circuit.getComponent(comp1).setLink(pin1, circuit.getComponent(comp2), pin2);
         }
+        circuit.simulate();
     } catch (const std::exception &e) {
         std::cerr << e.what() << std::endl;
         return 84;

--- a/tests/Exemple/nts_single/false_multiple.nts
+++ b/tests/Exemple/nts_single/false_multiple.nts
@@ -1,0 +1,10 @@
+# Basic wire, direct link false to output.
+#
+# FALSE ---> OUTPUT
+
+.chipsets:
+input in
+output out
+
+.links:
+in:1 out:1


### PR DESCRIPTION
Addition of a new `simulate` method, the inclusion of a new component type in the factory, and the invocation of the new `simulate` method in the parsing process.

Enhancements to `Circuit` class:

* `include/Component/Other/Circuit.hpp` Added a new `simulate` method to the `Circuit` class.
* `src/Component/Other/Circuit.cpp`: Implemented the new `simulate` method, which iterates over internal components to set them as not computed and then computes the output components.

Updates to `ComponentFactory`:

* `src/Factory/ComponentFactory.cpp`: Added support for creating `Component4017` instances in the `ComponentFactory`.

Modifications to parsing logic:

* `src/Parsing/Parse.cpp`: Added a call to the new `simulate` method in the initialization function to ensure the circuit is simulated after parsing.